### PR TITLE
Cast DBAL param to string before escaping

### DIFF
--- a/Clockwork/DataSource/DBALDataSource.php
+++ b/Clockwork/DataSource/DBALDataSource.php
@@ -168,7 +168,7 @@ class DBALDataSource extends DataSource implements SQLLogger
 				return '(' . $param . ')';
 			}
 		} else {
-			$param = htmlspecialchars($param); // Originally used the e() Laravel helper
+			$param = htmlspecialchars((string) $param); // Originally used the e() Laravel helper
 		}
 		return '"' . (string) $param . '"';
 	}


### PR DESCRIPTION
Fixes a deprecation notice when using PHP 8.1